### PR TITLE
Create $(datadir) before attempting to install timezeal.* to it.

### DIFF
--- a/elifekam
+++ b/elifekam
@@ -61,6 +61,7 @@ install-bin: eboard zseal
 	$(INSTALL) -m 0755 eboard $(bindir)/eboard
 	$(INSTALL) -m 0755 eboard-config   $(bindir)/eboard-config
 	$(INSTALL) -m 0755 eboard-addtheme $(bindir)/eboard-addtheme
+	$(INSTALL) -d $(datadir)
 	$(INSTALL) -m 0755 zseal $(datadir)/timeseal.$(osname)
 
 install-man:


### PR DESCRIPTION
Since the ``install-bin`` target is run before the ``install-data`` target during ``install``, it can happen that ``$(datadir)`` does not yet exist while trying to install ``zseal`` to ``$(datadir)/timeseal.$(osname)``.

This can lead to build failures, for example as reported for the Archlinux AUR build process (see https://aur.archlinux.org/packages/eboard/). I suggested a workaround for them to avoid the problem, but it would be much nicer to fix this right here, so I hope you will merge this tiny change :-).

