### PR TITLE
Fixed crash of application when selecting Crafty engine

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,9 @@ eboard ChangeLog
 
   * [all] minor adjustments to build scripts
 
+1.1.4
+  * [all] fixed crash when using crafty engine on ubuntu-based OS
+
 1.1.3
   * [all] Upgraded from gstreamer 0.10 to 1.0
  

--- a/configure
+++ b/configure
@@ -5,7 +5,7 @@ use IO::Handle;
 
 my $prefix      = "/usr/local";
 my $package     = "eboard";
-my $version     = "1.1.3";
+my $version     = "1.1.4";
 my $cxx         = "g++";
 my @cxxflags    = map { split } join(' ','-O6',$ENV{CXXFLAGS},$ENV{CPPFLAGS});
 my @cxxflagsdbg = ("-ggdb");

--- a/eboard-config
+++ b/eboard-config
@@ -17,7 +17,7 @@ prefix=/usr/local
 bindir=/usr/local/bin
 datadir=/usr/local/share
 package=eboard
-version=1.1.3
+version=1.1.4
 
 usage() 
 {

--- a/proto_xboard.cc
+++ b/proto_xboard.cc
@@ -1083,7 +1083,7 @@ void CraftyProtocol::readDialog() {
   snprintf(EngineCommandLine,512,"crafty bookpath=%s logpath=%s tbpath=%s",
 	   BookPath,LogPath,LogPath);
   if (!global.env.Home.empty())
-    snprintf(EngineRunDir,512,"%s/.eboard/craftylog",global.env.Home.c_str());
+    snprintf(EngineRunDir,256,"%s/.eboard/craftylog",global.env.Home.c_str());
   else
     strcpy(EngineRunDir,"/tmp");
 


### PR DESCRIPTION
This commit fix the crash of the application when selecting the Crafty engine, as reported at the following link: 

https://bugs.launchpad.net/ubuntu/+source/eboard/+bug/1306419

Bug found with the following conditions:
* OS: Linux Mint 19.3
* eboard v1.1.3
* Crafty  v23.4 (1 cpus)